### PR TITLE
Generalize MetropolisHastingSampler for random variables provided by jaxampler

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ limitations under the License. -->
 [![Python package](https://github.com/Qazalbash/jaxampler/actions/workflows/python-package.yml/badge.svg)](https://github.com/Qazalbash/jaxampler/actions/workflows/python-package.yml)
 [![Upload Python Package](https://github.com/Qazalbash/jaxampler/actions/workflows/python-publish.yml/badge.svg)](https://github.com/Qazalbash/jaxampler/actions/workflows/python-publish.yml)
 [![CodeQL](https://github.com/Qazalbash/jaxampler/actions/workflows/github-code-scanning/codeql/badge.svg)](https://github.com/Qazalbash/jaxampler/actions/workflows/github-code-scanning/codeql)
+
+![PyPI version](https://img.shields.io/pypi/v/jaxampler)
 [![Versions](https://img.shields.io/pypi/pyversions/jaxampler.svg)](https://pypi.org/project/jaxampler/)
 
 Jaxampler is a statistical sampling toolkit built on top of JAX. It provides a set of high-performance sampling algorithms for a wide range of statistical distributions. Jaxampler is designed to be easy to use and integrate with existing JAX workflows. It is also designed to be extensible, allowing users to easily add new sampling algorithms and statistical distributions.
@@ -65,12 +67,15 @@ The test suite is based on `pytest`. To run the tests, one needs to install pyte
 
 ## Monte Carlo Methods
 
-Jaxampler currently supports the following Monte Carlo methods:
+Jaxampler supports the following Monte Carlo methods:
 
+- [ ] Hamiltonian Monte Carlo
 - [x] Importance Sampling
 - [ ] Markov Chain Monte Carlo
+- [ ] Metropolis Adjusted Langevin Algorithm
 - [x] Monte Carlo Box Integration
 - [x] Monte Carlo Integration
+- [ ] Multiple-Try Metropolis
 - [ ] Sequential Monte Carlo
 - [ ] Variational Inference
 - [ ] Wang-Landau Sampling
@@ -78,12 +83,11 @@ Jaxampler currently supports the following Monte Carlo methods:
 
 ## Samplers
 
-Jaxampler currently supports the following samplers:
+Jaxampler supports the following samplers:
 
 - [x] Accept-Rejection Sampler
 - [x] Adaptive Accept-Rejection Sampler
 - [ ] Gibbs Sampler
-- [ ] Hamiltonian Monte Carlo Sampler
 - [x] Hastings Sampler
 - [x] Inverse Transform Sampler
 - [x] Metropolis-Hastings Sampler
@@ -91,7 +95,7 @@ Jaxampler currently supports the following samplers:
 
 ## Random Variables
 
-Jaxampler currently supports the following random variables:
+Jaxampler supports the following random variables:
 
 ### Discrete Random Variables
 

--- a/jaxampler/rvs/crvs/exponential.py
+++ b/jaxampler/rvs/crvs/exponential.py
@@ -63,8 +63,8 @@ class Exponential(ContinuousRV):
         if key is None:
             key = self.get_key(key)
         U = jax.random.uniform(key, shape=shape)
-        rvs_xal = jnp.log(-jnp.log(U)) - jnp.log(self._lmbda)
-        return jnp.exp(rvs_xal)
+        rvs_val = jnp.log(-jnp.log(U)) - jnp.log(self._lmbda)
+        return jnp.exp(rvs_val)
 
     def __repr__(self) -> str:
         string = f"Exponential(lmbda={self._lmbda}"

--- a/jaxampler/sampler/mhsampler.py
+++ b/jaxampler/sampler/mhsampler.py
@@ -12,76 +12,161 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Callable
+from typing import Any, Callable
 
-import tqdm
 from jax import Array
 from jax import numpy as jnp
 from jax.random import uniform
 from jax.typing import ArrayLike
+from tqdm import tqdm, trange
 
+from ..rvs import ContinuousRV
 from .sampler import Sampler
 
 
 class MetropolisHastingSampler(Sampler):
+    """Metropolis-Hasting Sampler Class"""
 
-    def __init__(self) -> None:
-        super().__init__()
+    def _walk(self,
+              q: Callable[[Any], ContinuousRV],
+              alpha: Callable,
+              xt: ArrayLike,
+              N: int,
+              key: Array = None) -> Array:
+        """single chain walk 
 
-    def _walk(
-        self,
-        q_rvs: Callable,
-        alpha: Callable,
-        xt: ArrayLike,
-        N: int,
-        key: Array = None,
-    ) -> Array:
+        This function is used to generate a single chain of samples from the
+        target distribution.
+
+        Parameters
+        ----------
+        q : Callable[[Any], ContinuousRV]
+            Proxy distribution
+        alpha : Callable
+            Acceptance probability function
+        xt : ArrayLike
+            Initial value
+        N : int
+            Number of samples
+        key : Array, optional
+            JAX PRNGKey, by default None
+
+        Returns
+        -------
+        Array
+            Samples from the target distribution
+        """
         if key is None:
             key = self.get_key(key)
         samples = jnp.empty((N,))
         t = 0
         while t < N:
-            x_prop = q_rvs(xt, (), key)
+            x_prop = q(xt).rvs(shape=(), key=key)
             key = self.get_key(key)
             u = uniform(key)
-            key = self.get_key(key)
             if u < alpha(xt, x_prop):
                 xt = x_prop
                 samples = samples.at[t].set(xt)
                 t += 1
+            key = self.get_key(key)
         return samples
 
     def sample(self,
-               f_pdf: Callable,
-               q_pdf: Callable,
-               q_rvs: Callable,
+               p: ContinuousRV,
+               q: Callable[[Any], ContinuousRV],
                burn_in: int,
                n_chains: int,
                x_curr: Array,
                N: int,
                key: Array = None,
                hasting_ratio: bool = False) -> Array:
+        """Sample function for Metropolis-Hasting Sampler
 
+        First, the sampler will run a burn-in phase to get the chain to
+        stationarity. Then, the sampler will run the sampling phase to generate
+        samples from the target distribution.
+
+        Parameters
+        ----------
+        p : ContinuousRV
+            Target distribution
+        q : Callable[[Any], ContinuousRV]
+            Proxy distribution
+        burn_in : int
+            Burn-in phase
+        n_chains : int
+            Number of chains
+        x_curr : Array
+            Initial values
+        N : int
+            Number of samples
+        key : Array, optional
+            JAX PRNGKey, by default None
+        hasting_ratio : bool, optional
+            Whether to use the Hasting Ratio or not, by default False
+
+        Returns
+        -------
+        Array
+            Samples from the target distribution
+        """
         x_curr = jnp.asarray(x_curr)
         assert x_curr.shape == (n_chains,)
 
         if hasting_ratio:
-            alpha = lambda x1, x2: ((f_pdf(x2) / f_pdf(x1)) * (q_pdf(x1, x2) / q_pdf(x2, x1))).clip(0.0, 1.0)
+            alpha = lambda x1, x2: ((p.pdf_x(x2) / p.pdf_x(x1)) * (q(x1).pdf_x(x2) / q(x2).pdf_x(x1))).clip(0.0, 1.0)
         else:
-            alpha = lambda x1, x2: (f_pdf(x2) / f_pdf(x1)).clip(0.0, 1.0)
+            alpha = lambda x1, x2: (p.pdf_x(x2) / p.pdf_x(x1)).clip(0.0, 1.0)
 
         if key is None:
             key = self.get_key(key)
 
-        for _ in tqdm.trange(burn_in, desc="Burn-in"):
-            x_curr = q_rvs(x_curr, (n_chains,), key)
+        for _ in trange(
+                burn_in,
+                desc="Burn-in",
+                unit="samples",
+        ):
+            x_curr = q(x_curr).rvs(shape=(n_chains,), key=key)
             key = self.get_key(key)
 
-        return jnp.column_stack(
-            [self._walk(
-                q_rvs,
-                alpha,
-                x_curr.at[i].get(),
-                N,
-                key,
-            ) for i in tqdm.trange(n_chains, desc="Sampling")])
+        pbar = tqdm(
+            total=N * n_chains,
+            desc="Sampling",
+            unit="samples",
+        )
+
+        T = jnp.zeros((n_chains,), dtype=jnp.int32)
+        samples = jnp.empty((N, n_chains))
+
+        while jnp.all(T < N):
+            x_prop = q(x_curr).rvs(shape=(), key=key)
+            key = self.get_key(key)
+            u = uniform(key, (n_chains,))
+            cond = u < alpha(x_curr, x_prop)
+            x_curr = jnp.where(cond == True, x_prop, x_curr)
+            for i in range(n_chains):
+                if cond[i]:
+                    samples = samples.at[T[i], i].set(x_prop[i])
+            T += cond
+            key = self.get_key(key)
+            t = int(cond.sum())
+            pbar.update(t)
+
+        pbar.display("Parallel Sampling Finished")
+
+        for i in range(n_chains):
+            if T[i] < N:
+                samples = samples.at[T[i]:, i].set(self._walk(
+                    q,
+                    alpha,
+                    x_curr[i],
+                    N - T[i],
+                    key,
+                ))
+                key = self.get_key(key)
+                t = int(N - T[i])
+                pbar.update(t)
+
+        pbar.close()
+
+        return samples


### PR DESCRIPTION
Generalize the `MetropolisHastingSampler` class in order to support random variables provided by `jaxampler`. This will allow for more flexibility in using the sampler with different types of random variables. This commit also contains the code where MCMC is vectorized over one device and it has improved the performance significantly.

Fixes #16