### PR TITLE
Fix issue with shapes of parameters in rvs method

### DIFF
--- a/jaxampler/rvs/crvs/beta.py
+++ b/jaxampler/rvs/crvs/beta.py
@@ -28,9 +28,9 @@ from .crvs import ContinuousRV
 class Beta(ContinuousRV):
 
     def __init__(self, alpha: ArrayLike, beta: ArrayLike, name: str = None) -> None:
-        self._alpha, self._beta = jx_cast(alpha, beta)
+        shape, self._alpha, self._beta = jx_cast(alpha, beta)
         self.check_params()
-        super().__init__(name)
+        super().__init__(name=name, shape=shape)
 
     def check_params(self) -> None:
         assert jnp.all(self._alpha > 0.0), "alpha must be positive"
@@ -59,6 +59,7 @@ class Beta(ContinuousRV):
     def rvs(self, shape: tuple[int, ...], key: Array = None) -> Array:
         if key is None:
             key = self.get_key(key)
+        shape += self._shape
         return jax.random.beta(key, self._alpha, self._beta, shape=shape)
 
     def __repr__(self) -> str:

--- a/jaxampler/rvs/crvs/boltzmann.py
+++ b/jaxampler/rvs/crvs/boltzmann.py
@@ -26,9 +26,9 @@ from .crvs import ContinuousRV
 class Boltzmann(ContinuousRV):
 
     def __init__(self, a: ArrayLike, name: str = None) -> None:
-        self._a, = jx_cast(a)
+        shape, self._a, = jx_cast(a)
         self.check_params()
-        super().__init__(name)
+        super().__init__(name=name, shape=shape)
 
     def check_params(self) -> None:
         assert jnp.all(self._a > 0.0), "a must be positive"

--- a/jaxampler/rvs/crvs/cauchy.py
+++ b/jaxampler/rvs/crvs/cauchy.py
@@ -27,9 +27,9 @@ from .crvs import ContinuousRV
 class Cauchy(ContinuousRV):
 
     def __init__(self, sigma: ArrayLike, loc: ArrayLike = 0, name: str = None) -> None:
-        self._sigma, self._loc = jx_cast(sigma, loc)
+        shape, self._sigma, self._loc = jx_cast(sigma, loc)
         self.check_params()
-        super().__init__(name)
+        super().__init__(name=name, shape=shape)
 
     def check_params(self) -> None:
         assert jnp.all(self._sigma > 0.0), "sigma must be positive"
@@ -57,6 +57,7 @@ class Cauchy(ContinuousRV):
     def rvs(self, shape: tuple[int, ...], key: Array = None) -> Array:
         if key is None:
             key = self.get_key(key)
+        shape += self._shape
         return jax.random.cauchy(key, shape=shape) * self._sigma + self._loc
 
     def __repr__(self) -> str:

--- a/jaxampler/rvs/crvs/chi2.py
+++ b/jaxampler/rvs/crvs/chi2.py
@@ -27,9 +27,9 @@ from .crvs import ContinuousRV
 class Chi2(ContinuousRV):
 
     def __init__(self, nu: ArrayLike, name: str = None) -> None:
-        self._nu, = jx_cast(nu)
+        shape, self._nu, = jx_cast(nu)
         self.check_params()
-        super().__init__(name)
+        super().__init__(name=name, shape=shape)
 
     def check_params(self) -> None:
         assert jnp.all(self._nu.dtype == jnp.int32), "nu must be an integer"
@@ -57,6 +57,7 @@ class Chi2(ContinuousRV):
     def rvs(self, shape: tuple[int, ...], key: Array = None) -> Array:
         if key is None:
             key = self.get_key(key)
+        shape += self._shape
         return jax.random.chisquare(key, self._nu, shape=shape)
 
     def __repr__(self) -> str:

--- a/jaxampler/rvs/crvs/crvs.py
+++ b/jaxampler/rvs/crvs/crvs.py
@@ -24,8 +24,8 @@ from ..rvs import GenericRV
 
 class ContinuousRV(GenericRV):
 
-    def __init__(self, name: str = None) -> None:
-        super().__init__(name)
+    def __init__(self, name: str = None, shape: tuple[int, ...] = None) -> None:
+        super().__init__(name=name, shape=shape)
 
     @partial(jit, static_argnums=(0,))
     def Z(self) -> ArrayLike:

--- a/jaxampler/rvs/crvs/exponential.py
+++ b/jaxampler/rvs/crvs/exponential.py
@@ -27,10 +27,10 @@ from .crvs import ContinuousRV
 class Exponential(ContinuousRV):
 
     def __init__(self, lmbda: ArrayLike, name: str = None) -> None:
-        self._lmbda, = jx_cast(lmbda)
+        shape, self._lmbda, = jx_cast(lmbda)
         self.check_params()
         self._scale = 1.0 / lmbda
-        super().__init__(name)
+        super().__init__(name=name, shape=shape)
 
     def check_params(self) -> None:
         assert jnp.all(self._lmbda > 0.0), "lmbda must be positive"
@@ -62,6 +62,7 @@ class Exponential(ContinuousRV):
     def rvs(self, shape: tuple[int, ...], key: Array = None) -> Array:
         if key is None:
             key = self.get_key(key)
+        shape += self._shape
         U = jax.random.uniform(key, shape=shape)
         rvs_val = jnp.log(-jnp.log(U)) - jnp.log(self._lmbda)
         return jnp.exp(rvs_val)

--- a/jaxampler/rvs/crvs/gamma.py
+++ b/jaxampler/rvs/crvs/gamma.py
@@ -27,9 +27,9 @@ from .crvs import ContinuousRV
 class Gamma(ContinuousRV):
 
     def __init__(self, alpha: ArrayLike, beta: ArrayLike, name: str = None) -> None:
-        self._alpha, self._beta = jx_cast(alpha, beta)
+        shape, self._alpha, self._beta = jx_cast(alpha, beta)
         self.check_params()
-        super().__init__(name)
+        super().__init__(name=name, shape=shape)
 
     def check_params(self) -> None:
         assert jnp.all(self._alpha > 0), "All alpha must be greater than 0"
@@ -58,6 +58,7 @@ class Gamma(ContinuousRV):
     def rvs(self, shape: tuple[int, ...], key: Array = None) -> Array:
         if key is None:
             key = self.get_key(key)
+        shape += self._shape
         return jax.random.gamma(key, self._alpha, shape=shape) / self._beta
 
     def __repr__(self) -> str:

--- a/jaxampler/rvs/crvs/logistic.py
+++ b/jaxampler/rvs/crvs/logistic.py
@@ -28,10 +28,10 @@ from .crvs import ContinuousRV
 class Logistic(ContinuousRV):
 
     def __init__(self, mu: ArrayLike = 0.0, scale: ArrayLike = 1.0, name: str = None) -> None:
-        self._scale, = jx_cast(scale)
+        shape, self._scale, = jx_cast(scale)
         self.check_params()
         self._mu = mu
-        super().__init__(name)
+        super().__init__(name=name, shape=shape)
 
     def check_params(self) -> None:
         assert jnp.all(self._scale > 0.0), "scale must be positive"
@@ -55,6 +55,7 @@ class Logistic(ContinuousRV):
     def rvs(self, shape: tuple[int, ...], key: Array = None) -> Array:
         if key is None:
             key = self.get_key(key)
+        shape += self._shape
         return jax.random.logistic(key, shape=shape) * self._scale + self._mu
 
     def __repr__(self) -> str:

--- a/jaxampler/rvs/crvs/lognormal.py
+++ b/jaxampler/rvs/crvs/lognormal.py
@@ -27,9 +27,9 @@ from .crvs import ContinuousRV
 class LogNormal(ContinuousRV):
 
     def __init__(self, mu: ArrayLike = 0.0, sigma: ArrayLike = 1.0, name: str = None) -> None:
-        self._mu, self._sigma = jx_cast(mu, sigma)
+        shape, self._mu, self._sigma = jx_cast(mu, sigma)
         self.check_params()
-        super().__init__(name)
+        super().__init__(name=name, shape=shape)
 
     def check_params(self) -> None:
         assert jnp.all(self._sigma > 0.0), "All sigma must be greater than 0.0"
@@ -59,6 +59,7 @@ class LogNormal(ContinuousRV):
     def rvs(self, shape: tuple[int, ...], key: Array = None) -> Array:
         if key is None:
             key = self.get_key(key)
+        shape += self._shape
         U = jax.random.uniform(key, shape=shape)
         return self.ppf_x(U)
 

--- a/jaxampler/rvs/crvs/normal.py
+++ b/jaxampler/rvs/crvs/normal.py
@@ -27,10 +27,10 @@ from .crvs import ContinuousRV
 class Normal(ContinuousRV):
 
     def __init__(self, mu: ArrayLike = 0.0, sigma: ArrayLike = 1.0, name: str = None) -> None:
-        self._mu, self._sigma = jx_cast(mu, sigma)
+        shape, self._mu, self._sigma = jx_cast(mu, sigma)
         self.check_params()
         self._logZ = 0.0
-        super().__init__(name)
+        super().__init__(name=name, shape=shape)
 
     def check_params(self) -> None:
         assert jnp.all(self._sigma > 0.0), "All sigma must be greater than 0.0"
@@ -58,6 +58,7 @@ class Normal(ContinuousRV):
     def rvs(self, shape: tuple[int, ...], key: Array = None) -> Array:
         if key is None:
             key = self.get_key(key)
+        shape += self._shape
         return jax.random.normal(key, shape=shape) * self._sigma + self._mu
 
     def __repr__(self) -> str:

--- a/jaxampler/rvs/crvs/pareto.py
+++ b/jaxampler/rvs/crvs/pareto.py
@@ -27,9 +27,9 @@ from .crvs import ContinuousRV
 class Pareto(ContinuousRV):
 
     def __init__(self, alpha: ArrayLike, scale: ArrayLike, name: str = None) -> None:
-        self._alpha, self._scale = jx_cast(alpha, scale)
+        shape, self._alpha, self._scale = jx_cast(alpha, scale)
         self.check_params()
-        super().__init__(name)
+        super().__init__(name=name, shape=shape)
 
     def check_params(self) -> None:
         assert jnp.all(self._alpha > 0.0), "alpha must be greater than 0"
@@ -68,6 +68,7 @@ class Pareto(ContinuousRV):
     def rvs(self, shape: tuple[int, ...], key: Array = None) -> Array:
         if key is None:
             key = self.get_key(key)
+        shape += self._shape
         return jax.random.pareto(key, self._alpha, shape=shape) * self._scale
 
     def __repr__(self) -> str:

--- a/jaxampler/rvs/crvs/rayleigh.py
+++ b/jaxampler/rvs/crvs/rayleigh.py
@@ -26,9 +26,9 @@ from .crvs import ContinuousRV
 class Rayleigh(ContinuousRV):
 
     def __init__(self, sigma: float, name: str = None) -> None:
-        self._sigma, = jx_cast(sigma)
+        shape, self._sigma, = jx_cast(sigma)
         self.check_params()
-        super().__init__(name)
+        super().__init__(name=name, shape=shape)
 
     def check_params(self) -> None:
         assert jnp.all(self._sigma > 0.0), "sigma must be positive"
@@ -60,6 +60,7 @@ class Rayleigh(ContinuousRV):
     def rvs(self, shape: tuple[int, ...], key: Array = None) -> Array:
         if key is None:
             key = self.get_key(key)
+        shape += self._shape
         return jax.random.rayleigh(key, scale=self._sigma, shape=shape)
 
     def __repr__(self) -> str:

--- a/jaxampler/rvs/crvs/studentt.py
+++ b/jaxampler/rvs/crvs/studentt.py
@@ -14,7 +14,8 @@
 
 from functools import partial
 
-from jax import jit
+import jax
+from jax import Array, jit
 from jax import numpy as jnp
 from jax.scipy.special import betainc
 from jax.scipy.stats import t as jax_t
@@ -27,9 +28,9 @@ from .crvs import ContinuousRV
 class StudentT(ContinuousRV):
 
     def __init__(self, nu: ArrayLike, name: str = None) -> None:
-        self._nu, = jx_cast(nu)
+        shape, self._nu, = jx_cast(nu)
         self.check_params()
-        super().__init__(name)
+        super().__init__(name=name, shape=shape)
 
     def check_params(self) -> None:
         assert jnp.all(self._nu > 0.0), "nu must be positive"
@@ -50,6 +51,12 @@ class StudentT(ContinuousRV):
     def ppf_x(self, x: ArrayLike) -> ArrayLike:
         """A method is addressed in this paper https://www.homepages.ucl.ac.uk/~ucahwts/lgsnotes/JCF_Student.pdf"""
         raise NotImplementedError
+
+    def rvs(self, shape: tuple[int, ...], key: Array = None) -> Array:
+        if key is None:
+            key = self.get_key(key)
+        shape += self._shape
+        return jax.random.t(key=key, df=self._nu, shape=shape)
 
     def __repr__(self) -> str:
         string = f"StudentT(nu={self._nu}"

--- a/jaxampler/rvs/crvs/triangular.py
+++ b/jaxampler/rvs/crvs/triangular.py
@@ -26,9 +26,9 @@ from .crvs import ContinuousRV
 class Triangular(ContinuousRV):
 
     def __init__(self, low: float = 0, mode: float = 0.5, high: float = 1, name: str = None) -> None:
-        self._low, self._mode, self._high = jx_cast(low, mode, high)
+        shape, self._low, self._mode, self._high = jx_cast(low, mode, high)
         self.check_params()
-        super().__init__(name)
+        super().__init__(name=name, shape=shape)
 
     def check_params(self) -> None:
         assert jnp.all(self._low <= self._high), "low must be less than or equal to high"
@@ -84,6 +84,7 @@ class Triangular(ContinuousRV):
     def rvs(self, shape: tuple[int, ...], key: Array = None) -> Array:
         if key is None:
             key = self.get_key(key)
+        shape += self._shape
         return jax.random.triangular(
             key,
             left=self._low,

--- a/jaxampler/rvs/crvs/truncnormal.py
+++ b/jaxampler/rvs/crvs/truncnormal.py
@@ -32,11 +32,11 @@ class TruncNormal(ContinuousRV):
                  low: ArrayLike = 0.0,
                  high: ArrayLike = 1.0,
                  name: str = None) -> None:
-        self._mu, self._sigma, self._low, self._high = jx_cast(mu, sigma, low, high)
+        shape, self._mu, self._sigma, self._low, self._high = jx_cast(mu, sigma, low, high)
         self.check_params()
         self._alpha = (self._low - self._mu) / self._sigma
         self._beta = (self._high - self._mu) / self._sigma
-        super().__init__(name)
+        super().__init__(name=name, shape=shape)
 
     def check_params(self) -> None:
         assert jnp.all(self._low < self._high), "low must be smaller than high"
@@ -85,6 +85,7 @@ class TruncNormal(ContinuousRV):
     def rvs(self, shape: tuple[int, ...], key: Array = None) -> Array:
         if key is None:
             key = self.get_key(key)
+        shape += self._shape
         return jax.random.truncated_normal(
             key,
             self._alpha,

--- a/jaxampler/rvs/crvs/truncpowerlaw.py
+++ b/jaxampler/rvs/crvs/truncpowerlaw.py
@@ -26,11 +26,11 @@ from .crvs import ContinuousRV
 class TruncPowerLaw(ContinuousRV):
 
     def __init__(self, alpha: ArrayLike, low: ArrayLike = 0, high: ArrayLike = 1, name: str = None) -> None:
-        self._alpha, self._low, self._high = jx_cast(alpha, low, high)
+        shape, self._alpha, self._low, self._high = jx_cast(alpha, low, high)
         self.check_params()
         self._beta = 1.0 + self._alpha
         self._logZ = self.logZ()
-        super().__init__(name)
+        super().__init__(name=name, shape=shape)
 
     def check_params(self) -> None:
         assert jnp.all(self._low > 0.0), "low must be greater than 0"

--- a/jaxampler/rvs/crvs/uniform.py
+++ b/jaxampler/rvs/crvs/uniform.py
@@ -27,9 +27,9 @@ from .crvs import ContinuousRV
 class Uniform(ContinuousRV):
 
     def __init__(self, low: ArrayLike = 0.0, high: ArrayLike = 1.0, name: str = None) -> None:
-        self._low, self._high = jx_cast(low, high)
+        shape, self._low, self._high = jx_cast(low, high)
         self.check_params()
-        super().__init__(name)
+        super().__init__(name, shape)
 
     def check_params(self) -> None:
         assert jnp.all(self._low < self._high), "All low must be less than high"
@@ -63,6 +63,7 @@ class Uniform(ContinuousRV):
     def rvs(self, shape: tuple[int, ...], key: Array = None) -> Array:
         if key is None:
             key = self.get_key(key)
+        shape += self._shape
         return jax.random.uniform(key, minval=self._low, maxval=self._high, shape=shape)
 
     def __repr__(self) -> str:

--- a/jaxampler/rvs/crvs/weibull.py
+++ b/jaxampler/rvs/crvs/weibull.py
@@ -26,10 +26,10 @@ from .crvs import ContinuousRV
 class Weibull(ContinuousRV):
 
     def __init__(self, lmbda: ArrayLike = 1.0, k: ArrayLike = 1.0, name: str = None) -> None:
-        self._lmbda, = jx_cast(lmbda)
+        shape, self._lmbda, = jx_cast(lmbda)
         self._k = k
         self.check_params()
-        super().__init__(name)
+        super().__init__(name=name, shape=shape)
 
     def check_params(self) -> None:
         assert jnp.all(self._lmbda > 0.0), "scale must be greater than 0"
@@ -59,6 +59,7 @@ class Weibull(ContinuousRV):
     def rvs(self, shape: tuple[int, ...], key: Array = None) -> Array:
         if key is None:
             key = self.get_key(key)
+        shape += self._shape
         U = jax.random.uniform(key, shape=shape)
         return self.ppf_x(U)
 

--- a/jaxampler/rvs/drvs/binomial.py
+++ b/jaxampler/rvs/drvs/binomial.py
@@ -39,10 +39,10 @@ class Binomial(DiscreteRV):
         name : str, optional
             Name of the random variable, by default None
         """
-        self._p, self._n = jx_cast(p, n)
+        shape, self._p, self._n = jx_cast(p, n)
         self.check_params()
         self._q = 1.0 - p
-        super().__init__(name)
+        super().__init__(name=name, shape=shape)
 
     def check_params(self) -> None:
         """Check the parameters of the random variable."""
@@ -72,6 +72,7 @@ class Binomial(DiscreteRV):
     def rvs(self, shape: tuple[int, ...], key: Array = None) -> Array:
         if key is None:
             key = self.get_key(key)
+        shape += self._shape
         return jax.random.binomial(key=key, n=self._n, p=self._p, shape=shape)
 
     def __repr__(self) -> str:

--- a/jaxampler/rvs/drvs/drvs.py
+++ b/jaxampler/rvs/drvs/drvs.py
@@ -24,8 +24,8 @@ from ..rvs import GenericRV
 
 class DiscreteRV(GenericRV):
 
-    def __init__(self, name: str = None) -> None:
-        super().__init__(name)
+    def __init__(self, name: str = None, shape: tuple[int, ...] = None) -> None:
+        super().__init__(name=name, shape=shape)
 
     # POINT VALUED
 

--- a/jaxampler/rvs/drvs/geometric.py
+++ b/jaxampler/rvs/drvs/geometric.py
@@ -28,10 +28,10 @@ class Geometric(DiscreteRV):
     """Geometric Random Variable"""
 
     def __init__(self, p: ArrayLike, name: str = None) -> None:
-        self._p, = jx_cast(p)
+        shape, self._p, = jx_cast(p)
         self.check_params()
         self._q = 1.0 - self._p
-        super().__init__(name)
+        super().__init__(name=name, shape=shape)
 
     def check_params(self) -> None:
         assert jnp.all(self._p >= 0.0), "All p must be greater than or equals to 0"
@@ -57,6 +57,7 @@ class Geometric(DiscreteRV):
     def rvs(self, shape: tuple[int, ...], key: Array = None) -> Array:
         if key is None:
             key = self.get_key(key)
+        shape += self._shape
         return jax.random.geometric(key, self._p, shape=shape)
 
     def __repr__(self) -> str:

--- a/jaxampler/rvs/drvs/poisson.py
+++ b/jaxampler/rvs/drvs/poisson.py
@@ -27,9 +27,9 @@ from .drvs import DiscreteRV
 class Poisson(DiscreteRV):
 
     def __init__(self, lmbda: ArrayLike, name: str = None) -> None:
-        self._lmbda, = jx_cast(lmbda)
+        shape, self._lmbda, = jx_cast(lmbda)
         self.check_params()
-        super().__init__(name)
+        super().__init__(name=name, shape=shape)
 
     def check_params(self) -> None:
         assert jnp.all(self._lmbda > 0.0), "Lambda must be positive"
@@ -49,6 +49,7 @@ class Poisson(DiscreteRV):
     def rvs(self, shape: tuple[int, ...], key: Array = None) -> Array:
         if key is None:
             key = self.get_key(key)
+        shape += self._shape
         return jax.random.poisson(key, self._lmbda, shape=shape)
 
     def __repr__(self) -> str:

--- a/jaxampler/rvs/rvs.py
+++ b/jaxampler/rvs/rvs.py
@@ -25,8 +25,9 @@ from ..jobj import JObj
 class GenericRV(JObj):
     """Generic random variable class."""
 
-    def __init__(self, name: str = None) -> None:
+    def __init__(self, name: str = None, shape: tuple[int, ...] = None) -> None:
         self._name = name
+        self._shape = shape
 
     def check_params(self) -> None:
         raise NotImplementedError

--- a/jaxampler/utils.py
+++ b/jaxampler/utils.py
@@ -41,7 +41,7 @@ def jx_cast(*args: ArrayLike) -> list[Array]:
     if not shapes or all(core.definitely_equal_shape(shapes[0], s) for s in shapes):
         return [jnp.asarray(arg) for arg in args]
     result_shape = lax.broadcast_shapes(*shapes)
-    return [jnp.asarray(a) for a in args]
+    return [result_shape] + [jnp.asarray(a) for a in args]
 
 
 fact = [1, 1, 2, 6, 24, 120, 720, 5_040, 40_320, 362_880, 3_628_800]


### PR DESCRIPTION
This pull request fixes an issue where the shapes of parameters were not influencing the rvs method of a random variable (distribution). The issue occurred when using n-dimensional parameters (n>0). The fix ensures that the rvs method correctly handles the shape parameter for both 0-dimensional and n-dimensional parameters. fixes #43.