### PR TITLE
Algebraic manipulation of random variables

### DIFF
--- a/jaxampler/_src/jobj.py
+++ b/jaxampler/_src/jobj.py
@@ -27,6 +27,10 @@ class JObj(object):
     def __init__(self, name: Optional[str] = None) -> None:
         self._name = name
 
+    @property
+    def name(self):
+        return self._name
+
     @staticmethod
     def get_key(key: Optional[Array] = None) -> Array:
         """Get a new JAX random key.

--- a/jaxampler/_src/montecarlo/montecarlogeneric.py
+++ b/jaxampler/_src/montecarlo/montecarlogeneric.py
@@ -20,7 +20,7 @@ from jax import Array, numpy as jnp, vmap
 
 from ..rvs.rvs import RandomVariable
 from ..typing import Numeric
-from ..utils import jx_cast
+from ..utils import jxam_array_cast
 from .integration import Integration
 
 
@@ -76,7 +76,7 @@ class MonteCarloGenericIntegration(Integration):
         key: Optional[Array] = kwargs.get("key", None)
         if key is None:
             key = self.get_key()
-        param_shape, low, high = jx_cast(low, high)
+        param_shape, low, high = jxam_array_cast(low, high)
         p_rv = p.rvs(shape=(N,) + param_shape, key=key)
         p_rv = p_rv[(p_rv >= low) & (p_rv <= high)]
         hx = vmap(h)(p_rv)

--- a/jaxampler/_src/rvs/beta.py
+++ b/jaxampler/_src/rvs/beta.py
@@ -23,7 +23,7 @@ from jax.scipy.stats import beta as jax_beta
 from tensorflow_probability.substrates import jax as tfp
 
 from ..typing import Numeric
-from ..utils import jx_cast
+from ..utils import jxam_array_cast
 from .rvs import RandomVariable
 
 
@@ -45,7 +45,7 @@ class Beta(RandomVariable):
         scale: Numeric | Any = 1.0,
         name: Optional[str] = None,
     ) -> None:
-        shape, self._alpha, self._beta, self._loc, self._scale = jx_cast(alpha, beta, loc, scale)
+        shape, self._alpha, self._beta, self._loc, self._scale = jxam_array_cast(alpha, beta, loc, scale)
         self.check_params()
         super().__init__(name=name, shape=shape)
 

--- a/jaxampler/_src/rvs/binomial.py
+++ b/jaxampler/_src/rvs/binomial.py
@@ -23,7 +23,7 @@ from jax.scipy.special import betainc
 from jax.scipy.stats import binom as jax_binom
 
 from ..typing import Numeric
-from ..utils import jx_cast
+from ..utils import jxam_array_cast
 from .rvs import RandomVariable
 
 
@@ -39,7 +39,7 @@ class Binomial(RandomVariable):
         :param n: Number of trials
         :param name: Name of the random variable
         """
-        shape, self._p, self._n = jx_cast(p, n)
+        shape, self._p, self._n = jxam_array_cast(p, n)
         self.check_params()
         self._q = 1.0 - self._p
         super().__init__(name=name, shape=shape)

--- a/jaxampler/_src/rvs/boltzmann.py
+++ b/jaxampler/_src/rvs/boltzmann.py
@@ -21,13 +21,13 @@ from jax import jit, numpy as jnp
 from jax.scipy.special import erf
 
 from ..typing import Numeric
-from ..utils import jx_cast
+from ..utils import jxam_array_cast
 from .rvs import RandomVariable
 
 
 class Boltzmann(RandomVariable):
     def __init__(self, a: Numeric | Any, name: Optional[str] = None) -> None:
-        shape, self._a = jx_cast(a)
+        shape, self._a = jxam_array_cast(a)
         self.check_params()
         super().__init__(name=name, shape=shape)
 

--- a/jaxampler/_src/rvs/cauchy.py
+++ b/jaxampler/_src/rvs/cauchy.py
@@ -22,13 +22,13 @@ from jax import Array, jit, numpy as jnp
 from jax.scipy.stats import cauchy as jax_cauchy
 
 from ..typing import Numeric
-from ..utils import jx_cast
+from ..utils import jxam_array_cast
 from .rvs import RandomVariable
 
 
 class Cauchy(RandomVariable):
     def __init__(self, loc: Numeric | Any = 0, scale: Numeric | Any = 1.0, name: Optional[str] = None) -> None:
-        shape, self._loc, self._scale = jx_cast(loc, scale)
+        shape, self._loc, self._scale = jxam_array_cast(loc, scale)
         self.check_params()
         super().__init__(name=name, shape=shape)
 

--- a/jaxampler/_src/rvs/chi2.py
+++ b/jaxampler/_src/rvs/chi2.py
@@ -22,7 +22,7 @@ from jax import Array, jit, numpy as jnp
 from jax.scipy.stats import chi2 as jax_chi2
 
 from ..typing import Numeric
-from ..utils import jx_cast
+from ..utils import jxam_array_cast
 from .rvs import RandomVariable
 
 
@@ -34,7 +34,7 @@ class Chi2(RandomVariable):
         scale: Numeric | Any = 1.0,
         name: Optional[str] = None,
     ) -> None:
-        shape, self._nu, self._loc, self._scale = jx_cast(nu, loc, scale)
+        shape, self._nu, self._loc, self._scale = jxam_array_cast(nu, loc, scale)
         self.check_params()
         super().__init__(name=name, shape=shape)
 

--- a/jaxampler/_src/rvs/exponential.py
+++ b/jaxampler/_src/rvs/exponential.py
@@ -22,7 +22,7 @@ from jax import Array, jit, numpy as jnp
 from jax.scipy.stats import expon as jax_expon
 
 from ..typing import Numeric
-from ..utils import jx_cast
+from ..utils import jxam_array_cast
 from .rvs import RandomVariable
 
 
@@ -33,7 +33,7 @@ class Exponential(RandomVariable):
         scale: Numeric | Any = 1.0,
         name: Optional[str] = None,
     ) -> None:
-        shape, self._loc, self._scale = jx_cast(loc, scale)
+        shape, self._loc, self._scale = jxam_array_cast(loc, scale)
         self.check_params()
         super().__init__(name=name, shape=shape)
 

--- a/jaxampler/_src/rvs/gamma.py
+++ b/jaxampler/_src/rvs/gamma.py
@@ -22,7 +22,7 @@ from jax import Array, jit, numpy as jnp
 from jax.scipy.stats import gamma as jax_gamma
 
 from ..typing import Numeric
-from ..utils import jx_cast
+from ..utils import jxam_array_cast
 from .rvs import RandomVariable
 
 
@@ -34,7 +34,7 @@ class Gamma(RandomVariable):
         scale: Numeric | Any = 1.0,
         name: Optional[str] = None,
     ) -> None:
-        shape, self._a, self._loc, self._scale = jx_cast(a, loc, scale)
+        shape, self._a, self._loc, self._scale = jxam_array_cast(a, loc, scale)
         self.check_params()
         super().__init__(name=name, shape=shape)
 

--- a/jaxampler/_src/rvs/geometric.py
+++ b/jaxampler/_src/rvs/geometric.py
@@ -22,7 +22,7 @@ from jax import Array, jit, numpy as jnp
 from jax.scipy.stats import geom as jax_geom
 
 from ..typing import Numeric
-from ..utils import jx_cast
+from ..utils import jxam_array_cast
 from .rvs import RandomVariable
 
 
@@ -30,7 +30,7 @@ class Geometric(RandomVariable):
     """Geometric Random Variable"""
 
     def __init__(self, p: Numeric | Any, loc: Numeric | Any = 0.0, name: Optional[str] = None) -> None:
-        shape, self._p, self._loc = jx_cast(p, loc)
+        shape, self._p, self._loc = jxam_array_cast(p, loc)
         self.check_params()
         self._q = 1.0 - self._p
         super().__init__(name=name, shape=shape)

--- a/jaxampler/_src/rvs/logistic.py
+++ b/jaxampler/_src/rvs/logistic.py
@@ -23,13 +23,13 @@ from jax.scipy.special import logit
 from jax.scipy.stats import logistic as jax_logistic
 
 from ..typing import Numeric
-from ..utils import jx_cast
+from ..utils import jxam_array_cast
 from .rvs import RandomVariable
 
 
 class Logistic(RandomVariable):
     def __init__(self, loc: Numeric | Any = 0.0, scale: Numeric | Any = 1.0, name: Optional[str] = None) -> None:
-        shape, self._loc, self._scale = jx_cast(loc, scale)
+        shape, self._loc, self._scale = jxam_array_cast(loc, scale)
         self.check_params()
         super().__init__(name=name, shape=shape)
 

--- a/jaxampler/_src/rvs/lognormal.py
+++ b/jaxampler/_src/rvs/lognormal.py
@@ -22,13 +22,13 @@ from jax import Array, jit, numpy as jnp
 from jax.scipy.special import log_ndtr, ndtr, ndtri
 
 from ..typing import Numeric
-from ..utils import jx_cast
+from ..utils import jxam_array_cast
 from .rvs import RandomVariable
 
 
 class LogNormal(RandomVariable):
     def __init__(self, loc: Numeric | Any = 0.0, scale: Numeric | Any = 1.0, name: Optional[str] = None) -> None:
-        shape, self._loc, self._scale = jx_cast(loc, scale)
+        shape, self._loc, self._scale = jxam_array_cast(loc, scale)
         self.check_params()
         super().__init__(name=name, shape=shape)
 

--- a/jaxampler/_src/rvs/normal.py
+++ b/jaxampler/_src/rvs/normal.py
@@ -22,13 +22,13 @@ from jax import Array, jit, numpy as jnp
 from jax.scipy.stats import norm as jax_norm
 
 from ..typing import Numeric
-from ..utils import jx_cast
+from ..utils import jxam_array_cast
 from .rvs import RandomVariable
 
 
 class Normal(RandomVariable):
     def __init__(self, loc: Numeric | Any = 0.0, scale: Numeric | Any = 1.0, name: Optional[str] = None) -> None:
-        shape, self._loc, self._scale = jx_cast(loc, scale)
+        shape, self._loc, self._scale = jxam_array_cast(loc, scale)
         self.check_params()
         self._logZ = 0.0
         super().__init__(name=name, shape=shape)

--- a/jaxampler/_src/rvs/pareto.py
+++ b/jaxampler/_src/rvs/pareto.py
@@ -22,7 +22,7 @@ from jax import Array, jit, numpy as jnp
 from jax.scipy.stats import pareto as jax_pareto
 
 from ..typing import Numeric
-from ..utils import jx_cast
+from ..utils import jxam_array_cast
 from .rvs import RandomVariable
 
 
@@ -30,7 +30,7 @@ class Pareto(RandomVariable):
     def __init__(
         self, a: Numeric | Any, loc: Numeric | Any = 0.0, scale: Numeric | Any = 1.0, name: Optional[str] = None
     ) -> None:
-        shape, self._a, self._loc, self._scale = jx_cast(a, loc, scale)
+        shape, self._a, self._loc, self._scale = jxam_array_cast(a, loc, scale)
         self.check_params()
         super().__init__(name=name, shape=shape)
 

--- a/jaxampler/_src/rvs/poisson.py
+++ b/jaxampler/_src/rvs/poisson.py
@@ -22,13 +22,13 @@ from jax import Array, jit, numpy as jnp
 from jax.scipy.stats import poisson as jax_poisson
 
 from ..typing import Numeric
-from ..utils import jx_cast
+from ..utils import jxam_array_cast
 from .rvs import RandomVariable
 
 
 class Poisson(RandomVariable):
     def __init__(self, mu: Numeric | Any, loc: Numeric | Any = 0.0, name: Optional[str] = None) -> None:
-        shape, self._mu, self._loc = jx_cast(mu, loc)
+        shape, self._mu, self._loc = jxam_array_cast(mu, loc)
         self.check_params()
         super().__init__(name=name, shape=shape)
 

--- a/jaxampler/_src/rvs/rayleigh.py
+++ b/jaxampler/_src/rvs/rayleigh.py
@@ -21,13 +21,13 @@ import jax
 from jax import Array, jit, numpy as jnp
 
 from ..typing import Numeric
-from ..utils import jx_cast
+from ..utils import jxam_array_cast
 from .rvs import RandomVariable
 
 
 class Rayleigh(RandomVariable):
     def __init__(self, loc: Numeric | Any = 0.0, sigma: Numeric | Any = 1.0, name: Optional[str] = None) -> None:
-        shape, self._loc, self._sigma = jx_cast(loc, sigma)
+        shape, self._loc, self._sigma = jxam_array_cast(loc, sigma)
         self.check_params()
         super().__init__(name=name, shape=shape)
 

--- a/jaxampler/_src/rvs/rvs.py
+++ b/jaxampler/_src/rvs/rvs.py
@@ -15,22 +15,22 @@
 from __future__ import annotations
 
 from functools import partial
-from typing import Callable, Optional
+from typing_extensions import Any, Callable, Optional
 
-import numpy as np
-from jax import jit, lax, numpy as jnp, vmap
-from jax._src import core
+from jax import jit, numpy as jnp, vmap
 from jaxtyping import Array
 
 from ..jobj import JObj
 from ..typing import Numeric
+from ..utils import jxam_shape_cast
 
 
 class RandomVariable(JObj):
-    """Generic random variable class."""
+    """Random variable class."""
 
     def __init__(self, name: Optional[str] = None, shape: tuple[int, ...] = ()) -> None:
         self._shape = shape
+        self._stack = []
         super().__init__(name=name)
 
     def check_params(self) -> None:
@@ -39,16 +39,32 @@ class RandomVariable(JObj):
     # POINT VALUED
 
     @partial(jit, static_argnums=(0,))
+    def _logpmf_x(self, *x: Numeric) -> Numeric:
+        raise NotImplementedError
+
+    @partial(jit, static_argnums=(0,))
+    def _logpdf_x(self, *x: Numeric) -> Numeric:
+        raise NotImplementedError
+
+    @partial(jit, static_argnums=(0,))
     def _logcdf_x(self, *x: Numeric) -> Numeric:
         raise NotImplementedError
 
     @partial(jit, static_argnums=(0,))
-    def _cdf_x(self, *x: Numeric) -> Numeric:
-        return jnp.exp(self._logcdf_x(*x))
-
-    @partial(jit, static_argnums=(0,))
     def _logppf_x(self, *x: Numeric) -> Numeric:
         raise NotImplementedError
+
+    @partial(jit, static_argnums=(0,))
+    def _pmf_x(self, *x: Numeric) -> Numeric:
+        return jnp.exp(self._logpmf_x(*x))
+
+    @partial(jit, static_argnums=(0,))
+    def _pdf_x(self, *x: Numeric) -> Numeric:
+        return jnp.exp(self._logpdf_x(*x))
+
+    @partial(jit, static_argnums=(0,))
+    def _cdf_x(self, *x: Numeric) -> Numeric:
+        return jnp.exp(self._logcdf_x(*x))
 
     @partial(jit, static_argnums=(0,))
     def _ppf_x(self, *x: Numeric) -> Numeric:
@@ -57,54 +73,104 @@ class RandomVariable(JObj):
     # VECTOR VALUED
 
     @partial(jit, static_argnums=(0,))
-    def _logcdf_v(self, *x: Numeric) -> Numeric:
-        return vmap(self._logcdf_x, in_axes=0)(*x)
+    def _logpmf_v(self, *x: Numeric) -> Numeric:
+        return vmap(self._logpmf_x, in_axes=0)(*x)
 
     @partial(jit, static_argnums=(0,))
-    def _cdf_v(self, *x: Numeric) -> Numeric:
-        return jnp.exp(self._logcdf_v(*x))
+    def _logpdf_v(self, *x: Numeric) -> Numeric:
+        return vmap(self._logpdf_x, in_axes=0)(*x)
+
+    @partial(jit, static_argnums=(0,))
+    def _logcdf_v(self, *x: Numeric) -> Numeric:
+        return vmap(self._logcdf_x, in_axes=0)(*x)
 
     @partial(jit, static_argnums=(0,))
     def _logppf_v(self, *x: Numeric) -> Numeric:
         return vmap(self._logppf_x, in_axes=0)(*x)
 
     @partial(jit, static_argnums=(0,))
+    def _pmf_v(self, *x: Numeric) -> Numeric:
+        return jnp.exp(self._logpmf_v(*x))
+
+    @partial(jit, static_argnums=(0,))
+    def _cdf_v(self, *x: Numeric) -> Numeric:
+        return jnp.exp(self._logcdf_v(*x))
+
+    @partial(jit, static_argnums=(0,))
+    def _pdf_v(self, *x: Numeric) -> Numeric:
+        return jnp.exp(self._logpdf_v(*x))
+
+    @partial(jit, static_argnums=(0,))
     def _ppf_v(self, *x: Numeric) -> Numeric:
         return jnp.exp(self._logppf_v(*x))
 
-    # XXF FACTORY METHODS
-    @staticmethod
-    def _pv_factory(
-        func_p: Callable[..., Numeric],
-        func_v: Callable[..., Numeric],
-        *x: Numeric,
-    ) -> Numeric:
-        # partially taken from the implementation of `jnp.broadcast_arrays`
-        shapes = [np.shape(arg) for arg in x]
-        if not shapes or all(core.definitely_equal_shape(shapes[0], s) for s in shapes):
-            shape = shapes[0]
-        else:
-            shape: tuple[int, ...] = lax.broadcast_shapes(*shapes)
+    def _rvs(self, shape: tuple[int, ...], key: Array) -> Array:
+        raise NotImplementedError
 
+    # XXF FACTORY METHODS
+
+    def _pv_factory(
+        self,
+        func_p_repr: Callable[[RandomVariable], Callable[[Numeric], Numeric]],
+        func_v_repr: Callable[[RandomVariable], Callable[[Numeric], Numeric]],
+        shape: tuple[int, ...],
+    ) -> Callable:
         if len(shape) < 2:
-            return func_p(*x)
-        return func_v(*x)
+            fn = func_p_repr
+        else:
+            fn = func_v_repr
+
+        if len(self._stack) == 0:
+            return lambda *args: fn(self)(*args)
+        return lambda *args: self._evaulate(fn, *args)
 
     @partial(jit, static_argnums=(0,))
-    def logcdf(self, *x: Numeric) -> Numeric:
-        return self._pv_factory(self._logcdf_x, self._logcdf_v, *x)
+    def pmf(self, *x: Numeric) -> Numeric:
+        shape = jxam_shape_cast(*x)
+        fn = self._pv_factory(lambda x: x._pmf_x, lambda x: x._pmf_v, shape)
+        return fn(*x)
+
+    @partial(jit, static_argnums=(0,))
+    def pdf(self, *x: Numeric) -> Numeric:
+        shape = jxam_shape_cast(*x)
+        fn = self._pv_factory(lambda x: x._pdf_x, lambda x: x._pdf_v, shape)
+        return fn(*x)
 
     @partial(jit, static_argnums=(0,))
     def cdf(self, *x: Numeric) -> Numeric:
-        return self._pv_factory(self._cdf_x, self._cdf_v, *x)
-
-    @partial(jit, static_argnums=(0,))
-    def logppf(self, *x: Numeric) -> Numeric:
-        return self._pv_factory(self._logppf_x, self._logppf_v, *x)
+        shape = jxam_shape_cast(*x)
+        fn = self._pv_factory(lambda x: x._cdf_x, lambda x: x._cdf_v, shape)
+        return fn(*x)
 
     @partial(jit, static_argnums=(0,))
     def ppf(self, *x: Numeric) -> Numeric:
-        return self._pv_factory(self._ppf_x, self._ppf_v, *x)
+        shape = jxam_shape_cast(*x)
+        fn = self._pv_factory(lambda x: x._ppf_x, lambda x: x._ppf_v, shape)
+        return fn(*x)
+
+    @partial(jit, static_argnums=(0,))
+    def logpmf(self, *x: Numeric) -> Numeric:
+        shape = jxam_shape_cast(*x)
+        fn = self._pv_factory(lambda x: x._logpmf_x, lambda x: x._logpmf_v, shape)
+        return fn(*x)
+
+    @partial(jit, static_argnums=(0,))
+    def logpdf(self, *x: Numeric) -> Numeric:
+        shape = jxam_shape_cast(*x)
+        fn = self._pv_factory(lambda x: x._logpdf_x, lambda x: x._logpdf_v, shape)
+        return fn(*x)
+
+    @partial(jit, static_argnums=(0,))
+    def logcdf(self, *x: Numeric) -> Numeric:
+        shape = jxam_shape_cast(*x)
+        fn = self._pv_factory(lambda x: x._logcdf_x, lambda x: x._logcdf_v, shape)
+        return fn(*x)
+
+    @partial(jit, static_argnums=(0,))
+    def logppf(self, *x: Numeric) -> Numeric:
+        shape = jxam_shape_cast(*x)
+        fn = self._pv_factory(lambda x: x._logppf_x, lambda x: x._logppf_v, shape)
+        return fn(*x)
 
     def rvs(self, shape: tuple[int, ...], key: Optional[Array] = None) -> Array:
         if key is None:
@@ -112,65 +178,90 @@ class RandomVariable(JObj):
         new_shape = shape + self._shape
         return self._rvs(shape=new_shape, key=key)
 
-    def _rvs(self, shape: tuple[int, ...], key: Array) -> Array:
-        raise NotImplementedError
+    # postfix notation methods
 
-    # POINT VALUED
+    def _add_expression(self, op: Callable, *args: Any) -> None:
+        stack: list[Any] = [op]
+        for arg in args:
+            if isinstance(arg, RandomVariable) and len(arg._stack) != 0:
+                stack.extend(arg._stack)
+            else:
+                stack.append(arg)
+        self._stack = stack
 
-    @partial(jit, static_argnums=(0,))
-    def _logpdf_x(self, *x: Numeric) -> Numeric:
-        raise NotImplementedError
+    def _evaulate(self, func: Callable, *args, **kwargs) -> Any:
+        s = []
+        s_ = []
+        for i in range(len(self._stack)):
+            if isinstance(self._stack[i], RandomVariable):
+                s_.append(func(self._stack[i])(*args, **kwargs))
+            else:
+                s_.append(self._stack[i])
+        for item in s_[::-1]:
+            if isinstance(item, Callable):
+                s.append(item(*[s.pop() for _ in range(item.__code__.co_argcount)]))
+            else:
+                s.append(item)
+        return s[-1]
 
-    @partial(jit, static_argnums=(0,))
-    def _pdf_x(self, *x: Numeric) -> Numeric:
-        return jnp.exp(self._logpdf_x(*x))
+    # arithmetic operations
 
-    # VECTOR VALUED
+    def __add__(self, other) -> RandomVariable:
+        new_variable = RandomVariable(name=f"({self.__repr__()} + {other.__repr__()})")
+        new_variable._add_expression(lambda x, y: x + y, self, other)
+        return new_variable
 
-    @partial(jit, static_argnums=(0,))
-    def _logpdf_v(self, *x: Numeric) -> Numeric:
-        return vmap(self._logpdf_x, in_axes=0)(*x)
+    def __sub__(self, other) -> RandomVariable:
+        new_variable = RandomVariable(name=f"({self.__repr__()} - {other.__repr__()})")
+        new_variable._add_expression(lambda x, y: x - y, self, other)
+        return new_variable
 
-    @partial(jit, static_argnums=(0,))
-    def _pdf_v(self, *x: Numeric) -> Numeric:
-        return jnp.exp(self._logpdf_v(*x))
+    def __neg__(self):
+        new_variable = RandomVariable(name=f"(-{self.__repr__()})")
+        new_variable._add_expression(lambda x: -x, self)
+        return new_variable
 
-    # FACTORY METHODS
+    def __mul__(self, other) -> RandomVariable:
+        new_variable = RandomVariable(name=f"({self.__repr__()} * {other.__repr__()})")
+        new_variable._add_expression(lambda x, y: x * y, self, other)
+        return new_variable
 
-    @partial(jit, static_argnums=(0,))
-    def logpdf(self, *x: Numeric) -> Numeric:
-        return self._pv_factory(self._logpdf_x, self._logpdf_v, *x)
+    def __truediv__(self, other) -> RandomVariable:
+        new_variable = RandomVariable(name=f"({self.__repr__()} / {other.__repr__()})")
+        new_variable._add_expression(lambda x, y: x / y, self, other)
+        return new_variable
 
-    @partial(jit, static_argnums=(0,))
-    def pdf(self, *x: Numeric) -> Numeric:
-        return self._pv_factory(self._pdf_x, self._pdf_v, *x)
+    def __pow__(self, power, modulo=None) -> RandomVariable:
+        new_variable = RandomVariable(name=f"({self.__repr__()}**{power})")
+        new_variable._add_expression(lambda x, y: jnp.power(x, y), self, power)
+        return new_variable
 
-    # POINT VALUED
+    # reverse arithmetic operations
 
-    @partial(jit, static_argnums=(0,))
-    def _logpmf_x(self, *k: Numeric) -> Numeric:
-        raise NotImplementedError
+    def __radd__(self, other) -> RandomVariable:
+        new_variable = RandomVariable(name=f"({other.__repr__()} + {self.__repr__()})")
+        new_variable._add_expression(lambda x, y: x + y, other, self)
+        return new_variable
 
-    @partial(jit, static_argnums=(0,))
-    def _pmf_x(self, *k: Numeric) -> Numeric:
-        return jnp.exp(self._logpmf_x(*k))
+    def __rsub__(self, other) -> RandomVariable:
+        new_variable = RandomVariable(name=f"({other.__repr__()} - {self.__repr__()})")
+        new_variable._add_expression(lambda x, y: x - y, other, self)
+        return new_variable
 
-    # VECTOR VALUED
+    def __rmul__(self, other) -> RandomVariable:
+        new_variable = RandomVariable(name=f"({other.__repr__()} * {self.__repr__()})")
+        new_variable._add_expression(lambda x, y: x * y, other, self)
+        return new_variable
 
-    @partial(jit, static_argnums=(0,))
-    def _logpmf_v(self, *k: Numeric) -> Numeric:
-        return vmap(self._logpmf_x, in_axes=0)(*k)
+    def __rtruediv__(self, other) -> RandomVariable:
+        new_variable = RandomVariable(name=f"({other.__repr__()} / {self.__repr__()})")
+        new_variable._add_expression(lambda x, y: x / y, other, self)
+        return new_variable
 
-    @partial(jit, static_argnums=(0,))
-    def _pmf_v(self, *k: Numeric) -> Numeric:
-        return jnp.exp(self._logpmf_v(*k))
+    def __repr__(self) -> str:
+        if self._name is None:
+            return ""
+        return self._name
 
-    # FACTORY METHODS
-
-    @partial(jit, static_argnums=(0,))
-    def logpmf(self, *k: Numeric) -> Numeric:
-        return self._pv_factory(self._logpmf_x, self._logpmf_v, *k)
-
-    @partial(jit, static_argnums=(0,))
-    def pmf(self, *k: Numeric) -> Numeric:
-        return self._pv_factory(self._pmf_x, self._pmf_v, *k)
+    def __str__(self) -> str:
+        return self.__repr__()

--- a/jaxampler/_src/rvs/studentt.py
+++ b/jaxampler/_src/rvs/studentt.py
@@ -23,7 +23,7 @@ from jax.scipy.special import betainc
 from jax.scipy.stats import t as jax_t
 
 from ..typing import Numeric
-from ..utils import jx_cast
+from ..utils import jxam_array_cast
 from .rvs import RandomVariable
 
 
@@ -35,7 +35,7 @@ class StudentT(RandomVariable):
         scale: Numeric | Any = 1.0,
         name: Optional[str] = None,
     ) -> None:
-        shape, self._df, self._loc, self._scale = jx_cast(df, loc, scale)
+        shape, self._df, self._loc, self._scale = jxam_array_cast(df, loc, scale)
         self.check_params()
         super().__init__(name=name, shape=shape)
 

--- a/jaxampler/_src/rvs/triangular.py
+++ b/jaxampler/_src/rvs/triangular.py
@@ -21,7 +21,7 @@ import jax
 from jax import Array, jit, lax, numpy as jnp
 
 from ..typing import Numeric
-from ..utils import jx_cast
+from ..utils import jxam_array_cast
 from .rvs import RandomVariable
 
 
@@ -33,7 +33,7 @@ class Triangular(RandomVariable):
         high: Numeric | Any = 1,
         name: Optional[str] = None,
     ) -> None:
-        shape, self._low, self._mode, self._high = jx_cast(low, mode, high)
+        shape, self._low, self._mode, self._high = jxam_array_cast(low, mode, high)
         self.check_params()
         super().__init__(name=name, shape=shape)
 

--- a/jaxampler/_src/rvs/truncnormal.py
+++ b/jaxampler/_src/rvs/truncnormal.py
@@ -22,7 +22,7 @@ from jax import Array, jit, numpy as jnp
 from jax.scipy.stats import truncnorm as jax_truncnorm
 
 from ..typing import Numeric
-from ..utils import jx_cast
+from ..utils import jxam_array_cast
 from .rvs import RandomVariable
 
 
@@ -35,7 +35,7 @@ class TruncNormal(RandomVariable):
         high: Numeric | Any = 1.0,
         name: Optional[str] = None,
     ) -> None:
-        shape, self._loc, self._scale, self._low, self._high = jx_cast(loc, scale, low, high)
+        shape, self._loc, self._scale, self._low, self._high = jxam_array_cast(loc, scale, low, high)
         self.check_params()
         self._alpha = (self._low - self._loc) / self._scale
         self._beta = (self._high - self._loc) / self._scale

--- a/jaxampler/_src/rvs/truncpowerlaw.py
+++ b/jaxampler/_src/rvs/truncpowerlaw.py
@@ -22,7 +22,7 @@ from jax import jit, numpy as jnp
 from jaxtyping import Array
 
 from ..typing import Numeric
-from ..utils import jx_cast
+from ..utils import jxam_array_cast
 from .rvs import RandomVariable
 
 
@@ -34,7 +34,7 @@ class TruncPowerLaw(RandomVariable):
         high: Numeric | Any,
         name: Optional[str] = None,
     ) -> None:
-        shape, self._alpha, self._low, self._high = jx_cast(alpha, low, high)
+        shape, self._alpha, self._low, self._high = jxam_array_cast(alpha, low, high)
         self.check_params()
         self._beta = 1.0 + self._alpha
         self._logZ = self.logZ()

--- a/jaxampler/_src/rvs/uniform.py
+++ b/jaxampler/_src/rvs/uniform.py
@@ -23,13 +23,13 @@ from jax.scipy.stats import uniform as jax_uniform
 from jaxtyping import Array
 
 from ..typing import Numeric
-from ..utils import jx_cast
+from ..utils import jxam_array_cast
 from .rvs import RandomVariable
 
 
 class Uniform(RandomVariable):
     def __init__(self, low: Numeric | Any, high: Numeric | Any, name: Optional[str] = None) -> None:
-        shape, self._low, self._high = jx_cast(low, high)
+        shape, self._low, self._high = jxam_array_cast(low, high)
         self.check_params()
         super().__init__(name, shape)
 

--- a/jaxampler/_src/rvs/weibull.py
+++ b/jaxampler/_src/rvs/weibull.py
@@ -21,7 +21,7 @@ import jax
 from jax import Array, jit, numpy as jnp
 
 from ..typing import Numeric
-from ..utils import jx_cast
+from ..utils import jxam_array_cast
 from .rvs import RandomVariable
 
 
@@ -33,7 +33,7 @@ class Weibull(RandomVariable):
         scale: Numeric | Any = 1.0,
         name: Optional[str] = None,
     ) -> None:
-        shape, self._k, self._loc, self._scale = jx_cast(k, loc, scale)
+        shape, self._k, self._loc, self._scale = jxam_array_cast(k, loc, scale)
         self.check_params()
         super().__init__(name=name, shape=shape)
 

--- a/jaxampler/_src/typing.py
+++ b/jaxampler/_src/typing.py
@@ -14,7 +14,7 @@
 
 from __future__ import annotations
 
-from typing import Union
+from typing_extensions import Union
 
 import numpy as np
 from jaxtyping import Array

--- a/jaxampler/utils.py
+++ b/jaxampler/utils.py
@@ -14,4 +14,9 @@
 
 from __future__ import annotations
 
-from jaxampler._src.utils import jx_cast as jx_cast, nCr as nCr, nPr as nPr
+from jaxampler._src.utils import (
+    jxam_array_cast as jxam_array_cast,
+    jxam_shape_cast as jxam_shape_cast,
+    nCr as nCr,
+    nPr as nPr,
+)

--- a/tests/rvs_test.py
+++ b/tests/rvs_test.py
@@ -1,0 +1,71 @@
+#  Copyright 2023 The Jaxampler Authors
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+
+import sys
+
+from jax import numpy as jnp
+
+sys.path.append("../jaxampler")
+from jaxampler.rvs import Normal, Beta
+
+
+class TestRandomVariable:
+    beta = Beta(alpha=2, beta=2)
+    norms = [Normal(loc=i, scale=1) for i in jnp.linspace(-5, 5, 30)]
+    xx = jnp.linspace(-5, 5, 1000)
+
+    def test_adding_rvs(self):
+        Z = sum(self.norms)
+        assert jnp.allclose(Z.pdf(self.xx), sum(norm.pdf(self.xx) for norm in self.norms))
+
+    def test_adding_number(self):
+        Z = self.norms[0] + 2.6
+        assert jnp.allclose(Z.pdf(self.xx), self.norms[0].pdf(self.xx) + 2.6)
+
+    def test_subtracting_rvs(self):
+        Z = self.norms[0] - self.norms[1]
+        assert jnp.allclose(Z.pdf(self.xx), self.norms[0].pdf(self.xx) - self.norms[1].pdf(self.xx))
+
+    def test_subtracting_number(self):
+        Z = self.norms[0] - 2.6
+        assert jnp.allclose(Z.pdf(self.xx), self.norms[0].pdf(self.xx) - 2.6)
+
+    def test_multiplying_rvs(self):
+        Z = self.norms[0] * self.norms[1]
+        assert jnp.allclose(Z.pdf(self.xx), self.norms[0].pdf(self.xx) * self.norms[1].pdf(self.xx))
+
+    def test_multiplying_number(self):
+        Z = self.norms[0] * 2.6
+        assert jnp.allclose(Z.pdf(self.xx), self.norms[0].pdf(self.xx) * 2.6)
+
+    def test_dividing_rvs(self):
+        Z = self.norms[0] / self.norms[1]
+        assert jnp.allclose(Z.pdf(self.xx), self.norms[0].pdf(self.xx) / self.norms[1].pdf(self.xx))
+
+    def test_dividing_number(self):
+        Z = self.norms[0] / 2.6
+        assert jnp.allclose(Z.pdf(self.xx), self.norms[0].pdf(self.xx) / 2.6)
+
+    def test_powering_rvs(self):
+        Z = self.norms[0] ** self.norms[1]
+        assert jnp.allclose(Z.pdf(self.xx), self.norms[0].pdf(self.xx) ** self.norms[1].pdf(self.xx))
+
+    def test_powering_number(self):
+        Z = self.norms[0] ** 2.6
+        assert jnp.allclose(Z.pdf(self.xx), self.norms[0].pdf(self.xx) ** 2.6)
+
+    def test_negating_rvs(self):
+        Z = -self.norms[0]
+        assert jnp.allclose(Z.pdf(self.xx), -self.norms[0].pdf(self.xx))

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -19,14 +19,14 @@ from jax import numpy as jnp
 
 
 sys.path.append("../jaxampler")
-from jaxampler.utils import jx_cast, nCr, nPr
+from jaxampler.utils import jxam_array_cast, nCr, nPr
 
 
 class TestUtils:
     def test_jx_cast_success(self):
         a = 1
         b = [1, 2, 3]
-        shape, casted_a, casted_b = jx_cast(a, b)
+        shape, casted_a, casted_b = jxam_array_cast(a, b)
         assert shape == (3,)
         assert isinstance(casted_a, jnp.ndarray)
         assert isinstance(casted_b, jnp.ndarray)
@@ -39,11 +39,11 @@ class TestUtils:
         g = jnp.array([[1, 2, 3], [4, 5, 6]])
         h = jnp.array([[1, 2]])
         with pytest.raises(ValueError):
-            jx_cast(g, h)
+            jxam_array_cast(g, h)
 
     def test_incompatible_shapes(self):
         with pytest.raises(ValueError):
-            jx_cast([[0.3], 0.5], [0.5])
+            jxam_array_cast([[0.3], 0.5], [0.5])
 
     def test_nPr_exist(self):
         assert nPr(5, 3) == 60


### PR DESCRIPTION
Instead of using Expression Tree, we have used postfix notation.
Fixes #72 and fixes #92.